### PR TITLE
Feat/payment persist

### DIFF
--- a/backend/src/main/java/org/team4/project/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/controller/PaymentController.java
@@ -1,5 +1,10 @@
 package org.team4.project.domain.payment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +16,9 @@ import org.team4.project.domain.payment.dto.PaymentConfirmRequestDTO;
 import org.team4.project.domain.payment.dto.PaymentResponseDTO;
 import org.team4.project.domain.payment.dto.SavePaymentRequestDTO;
 import org.team4.project.domain.payment.service.PaymentService;
+import org.team4.project.global.exception.ErrorResponse;
 
+@Tag(name = "Payment API", description = "결제 기능 관련 API")
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
@@ -19,19 +26,23 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
-    /**
-     * 결제 승인
-     */
     //TODO : 사용자 ID와 서비스 ID를 전달받아 결제 완료 후 DB 저장
+    @Operation(
+            summary = "결제 승인 요청 API",
+            description = "실제 토스 결제 승인 API를 요청합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "결제 승인 요청 성공", content = @Content(schema = @Schema(implementation = PaymentResponseDTO.class))),
+                    @ApiResponse(responseCode = "400", description = "결제 승인 요청 실패, 요청 데이터와 임시 저장된 데이터 불일치", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            }
+    )
     @PostMapping("/confirm")
     public ResponseEntity<PaymentResponseDTO> confirmPayment(@Valid @RequestBody PaymentConfirmRequestDTO paymentConfirmRequestDTO) {
         PaymentResponseDTO response = paymentService.confirmPayment(paymentConfirmRequestDTO);
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * 결제 요청 전 요청할 데이터 임시 저장, 결제 승인보다 먼저 호출
-     */
+    @Operation(summary = "결제 요청 데이터 임시 저장 API", description = "결제를 요청하기 전에 서버에 임시로 저장합니다. 결제 승인 요청 전에 반드시 요청해야 하며, 결제 요청과 승인 사이에 데이터 무결성을 위함입니다.")
+    @ApiResponse(responseCode = "200", description = "데이터 임시 저장 성공")
     @PostMapping("/save")
     public ResponseEntity<?> savePayment(@Valid @RequestBody SavePaymentRequestDTO savePaymentRequestDTO) {
         paymentService.savePayment(savePaymentRequestDTO);

--- a/backend/src/main/java/org/team4/project/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/controller/PaymentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.team4.project.domain.payment.dto.PaymentConfirmRequestDTO;
+import org.team4.project.domain.payment.dto.PaymentResponseDTO;
 import org.team4.project.domain.payment.dto.SavePaymentRequestDTO;
 import org.team4.project.domain.payment.service.PaymentService;
 
@@ -23,9 +24,9 @@ public class PaymentController {
      */
     //TODO : 사용자 ID와 서비스 ID를 전달받아 결제 완료 후 DB 저장
     @PostMapping("/confirm")
-    public ResponseEntity<?> confirmPayment(@Valid @RequestBody PaymentConfirmRequestDTO paymentConfirmRequestDTO) {
-        paymentService.confirmPayment(paymentConfirmRequestDTO);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<PaymentResponseDTO> confirmPayment(@Valid @RequestBody PaymentConfirmRequestDTO paymentConfirmRequestDTO) {
+        PaymentResponseDTO response = paymentService.confirmPayment(paymentConfirmRequestDTO);
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/backend/src/main/java/org/team4/project/domain/payment/dto/PaymentConfirmRequestDTO.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/dto/PaymentConfirmRequestDTO.java
@@ -1,11 +1,22 @@
 package org.team4.project.domain.payment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record PaymentConfirmRequestDTO(
-        @NotBlank String paymentKey,
-        @NotBlank String orderId,
-        @NotNull @PositiveOrZero Integer amount) {
+        @NotBlank @Schema(description = "결제의 키값, 결제를 식별하는 역할", requiredMode = REQUIRED, maxLength = 200)
+        String paymentKey,
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Za-z0-9_-]{6,64}$", message = "영문 대소문자, 숫자, 특수문자(-, _)만 허용하며 6~64자여야 합니다.")
+        @Schema(description = "주문 번호, 주문할 결제를 식별하는 역할 (영문 대소문자, 숫자, 특수문자(-, _)로 이루어진 6자 이상 64자 이하의 문자열)", requiredMode = REQUIRED, minLength = 6, maxLength = 64)
+        String orderId,
+
+        @NotNull @PositiveOrZero @Schema(description = "결제할 금액", requiredMode = REQUIRED)
+        Integer amount) {
 }

--- a/backend/src/main/java/org/team4/project/domain/payment/dto/PaymentResponseDTO.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/dto/PaymentResponseDTO.java
@@ -1,5 +1,12 @@
 package org.team4.project.domain.payment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 //TODO : 더 자세한 정보 필요하면 필드 추가
-public record PaymentResponseDTO(String receiptUrl) {
+public record PaymentResponseDTO(
+
+        @Schema(description = "발행된 영수증 정보", requiredMode = NOT_REQUIRED)
+        String receiptUrl) {
 }

--- a/backend/src/main/java/org/team4/project/domain/payment/dto/PaymentResponseDTO.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/dto/PaymentResponseDTO.java
@@ -1,0 +1,5 @@
+package org.team4.project.domain.payment.dto;
+
+//TODO : 더 자세한 정보 필요하면 필드 추가
+public record PaymentResponseDTO(String receiptUrl) {
+}

--- a/backend/src/main/java/org/team4/project/domain/payment/dto/SavePaymentRequestDTO.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/dto/SavePaymentRequestDTO.java
@@ -1,10 +1,20 @@
 package org.team4.project.domain.payment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record SavePaymentRequestDTO(
-        @NotBlank String orderId,
-        @NotNull @PositiveOrZero Integer amount) {
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Za-z0-9_-]{6,64}$", message = "영문 대소문자, 숫자, 특수문자(-, _)만 허용하며 6~64자여야 합니다.")
+        @Schema(description = "주문번호, 주문할 결제를 식별하는 역할 (영문 대소문자, 숫자, 특수문자(-, _)로 이루어진 6자 이상 64자 이하의 문자열)", requiredMode = REQUIRED, minLength = 6, maxLength = 64)
+        String orderId,
+
+        @NotNull @PositiveOrZero @Schema(description = "결제할 금액", requiredMode = REQUIRED)
+        Integer amount) {
 }

--- a/backend/src/main/java/org/team4/project/domain/payment/entity/Payment.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/entity/Payment.java
@@ -1,0 +1,46 @@
+package org.team4.project.domain.payment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.team4.project.global.jpa.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+    @Id
+    private String paymentKey;
+
+    @Column(nullable = false)
+    private String orderId;
+
+    @Column(nullable = false)
+    private int totalAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus paymentStatus;
+
+    @Column(nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    private LocalDateTime approvedAt;
+
+    //TODO : 사용자, 서비스 외래키 연결
+}

--- a/backend/src/main/java/org/team4/project/domain/payment/entity/PaymentMethod.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/entity/PaymentMethod.java
@@ -1,0 +1,28 @@
+package org.team4.project.domain.payment.entity;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum PaymentMethod {
+
+    CARD("카드"),
+    VIRTUAL_ACCOUNT("가상계좌"),
+    EASY_PAY("간편결제"),
+    MOBILE_PHONE("휴대폰"),
+    BANK_TRANSFER("계좌이체"),
+    CULTURE_GIFT_CERTIFICATE("문화상품권"),
+    BOOK_GIFT_CERTIFICATE("도서문화상품권"),
+    GAME_GIFT_CERTIFICATE("게임문화상품권");
+
+    private final String koreanName;
+
+    public static PaymentMethod of(String value) {
+        for (PaymentMethod paymentMethod : values()) {
+            if (paymentMethod.koreanName.equalsIgnoreCase(value)) {
+                return paymentMethod;
+            }
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 결제 방법입니다: " + value);
+    }
+}

--- a/backend/src/main/java/org/team4/project/domain/payment/entity/PaymentStatus.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,22 @@
+package org.team4.project.domain.payment.entity;
+
+public enum PaymentStatus {
+    READY,
+    IN_PROGRESS,
+    WAITING_FOR_DEPOSIT,
+    DONE,
+    CANCELED,
+    PARTIAL_CANCELED,
+    ABORTED,
+    EXPIRED;
+
+    public static PaymentStatus of(String value) {
+        for (PaymentStatus paymentStatus : values()) {
+            if (paymentStatus.name().equalsIgnoreCase(value)) {
+                return paymentStatus;
+            }
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 결제 상태입니다: " + value);
+    }
+}

--- a/backend/src/main/java/org/team4/project/domain/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package org.team4.project.domain.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.team4.project.domain.payment.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, String> {
+}

--- a/backend/src/main/java/org/team4/project/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/service/PaymentService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.team4.project.domain.payment.dto.PaymentConfirmRequestDTO;
+import org.team4.project.domain.payment.dto.PaymentResponseDTO;
 import org.team4.project.domain.payment.dto.SavePaymentRequestDTO;
 import org.team4.project.domain.payment.entity.Payment;
 import org.team4.project.domain.payment.entity.PaymentMethod;
@@ -35,7 +36,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
 
     @Transactional
-    public void confirmPayment(PaymentConfirmRequestDTO paymentConfirmRequestDTO) {
+    public PaymentResponseDTO confirmPayment(PaymentConfirmRequestDTO paymentConfirmRequestDTO) {
         String orderId = paymentConfirmRequestDTO.orderId();
         Integer amount = paymentConfirmRequestDTO.amount();
 
@@ -45,6 +46,9 @@ public class PaymentService {
 
         paymentRepository.save(convertToEntity(response));
         redisRepository.deleteValue(generateKey(orderId));
+
+        String receiptUrl = response.get("receipt").get("url").asText(null);
+        return new PaymentResponseDTO(receiptUrl);
     }
 
     public void savePayment(SavePaymentRequestDTO savePaymentRequestDTO) {

--- a/backend/src/main/java/org/team4/project/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/org/team4/project/domain/payment/service/PaymentService.java
@@ -5,13 +5,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.team4.project.domain.payment.dto.PaymentConfirmRequestDTO;
 import org.team4.project.domain.payment.dto.SavePaymentRequestDTO;
+import org.team4.project.domain.payment.entity.Payment;
+import org.team4.project.domain.payment.entity.PaymentMethod;
+import org.team4.project.domain.payment.entity.PaymentStatus;
 import org.team4.project.domain.payment.exception.PaymentException;
 import org.team4.project.domain.payment.infra.PaymentClient;
+import org.team4.project.domain.payment.repository.PaymentRepository;
 import org.team4.project.global.redis.RedisRepository;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Objects;
 
 @Slf4j
@@ -20,9 +28,13 @@ import java.util.Objects;
 @Transactional(readOnly = true)
 public class PaymentService {
 
+    private static final ZoneId ZONE_ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
     private final PaymentClient paymentClient;
     private final RedisRepository redisRepository;
+    private final PaymentRepository paymentRepository;
 
+    @Transactional
     public void confirmPayment(PaymentConfirmRequestDTO paymentConfirmRequestDTO) {
         String orderId = paymentConfirmRequestDTO.orderId();
         Integer amount = paymentConfirmRequestDTO.amount();
@@ -30,8 +42,9 @@ public class PaymentService {
         verifyTempPayment(orderId, amount);
 
         JsonNode response = paymentClient.confirmPayment(paymentConfirmRequestDTO);
+
+        paymentRepository.save(convertToEntity(response));
         redisRepository.deleteValue(generateKey(orderId));
-        log.info("response = {}", response);
     }
 
     public void savePayment(SavePaymentRequestDTO savePaymentRequestDTO) {
@@ -51,6 +64,37 @@ public class PaymentService {
             log.debug("orderId: {}", orderId);
             throw new PaymentException("결제 금액 불일치 또는 임시 데이터가 존재하지 않습니다.");
         }
+    }
+
+    private Payment convertToEntity(JsonNode response) {
+        String orderId = response.get("orderId").asText();
+        String paymentKey = response.get("paymentKey").asText();
+
+        PaymentStatus paymentStatus = PaymentStatus.of(response.get("status").asText());
+        PaymentMethod paymentMethod = PaymentMethod.of(response.get("method").asText());
+
+        LocalDateTime requestedAt = parseToLocalDateTime(response.get("requestedAt").asText());
+        LocalDateTime approvedAt = parseToLocalDateTime(response.get("approvedAt").asText(null));
+
+        int totalAmount = response.get("totalAmount").asInt();
+
+        return Payment.builder()
+                      .paymentKey(paymentKey)
+                      .orderId(orderId)
+                      .paymentMethod(paymentMethod)
+                      .paymentStatus(paymentStatus)
+                      .requestedAt(requestedAt)
+                      .approvedAt(approvedAt)
+                      .totalAmount(totalAmount)
+                      .build();
+    }
+
+    private LocalDateTime parseToLocalDateTime(String timestamp) {
+        if (!StringUtils.hasText(timestamp)) {
+            return null;
+        }
+
+        return OffsetDateTime.parse(timestamp).atZoneSameInstant(ZONE_ASIA_SEOUL).toLocalDateTime();
     }
 
     private String generateKey(String orderId) {


### PR DESCRIPTION
## 긴급 처리 사유

## 📂 작업 내용

closes #18 

- [x] 결제 관련 엔티티 정의
- [x] 현재까지 만든 결제 관련 API Swagger 문서화 적용

## 💡 자세한 설명

- 결제 승인 요청 정상적으로 성공 시 다음 필드를 저장합니다.
  - 결제 키값
  - 주문번호
  - 결제수단
  - 총 결제금액
  - 결제 처리 상태
  - 결제가 일어난 날짜와 시간 정보
  - 결제 승인이 일어난 날짜와 시간 정보
- 결제 승인 요청 정상적으로 성공 시 다음 정보를 응답합니다.
  - 발행된 영수증 정보(url)
- 결제 관련 API 및 DTO에 Swagger 문서화 적용했습니다.

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment confirmation now returns a receipt URL in the response.
  * Payments are stored for future reference, including status, method, and timestamps.
* **Improvements**
  * Stricter validation for payment inputs (orderId, paymentKey, amount) with clearer error messages.
* **Documentation**
  * Added comprehensive OpenAPI/Swagger documentation for Payment APIs, including request/response schemas and endpoint descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->