### PR TITLE
Feat/auth api integration

### DIFF
--- a/backend/src/main/java/org/team4/project/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/org/team4/project/domain/member/controller/MemberController.java
@@ -3,10 +3,14 @@ package org.team4.project.domain.member.controller;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.team4.project.domain.member.dto.MemberProfileResponseDTO;
 import org.team4.project.domain.member.dto.MemberSignUpRequestDTO;
 import org.team4.project.domain.member.service.AuthService;
 import org.team4.project.domain.member.service.MemberService;
+import org.team4.project.global.security.CustomUserDetails;
 import org.team4.project.global.util.CookieUtil;
 
 import static org.team4.project.global.security.jwt.JwtContents.*;
@@ -35,5 +39,11 @@ public class MemberController {
     @PostMapping("/token/logout")
     public void logout(@CookieValue(name = TOKEN_TYPE_REFRESH, required = false) String refreshToken) {
         authService.logout(refreshToken);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberProfileResponseDTO> getProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        MemberProfileResponseDTO profile = memberService.getProfile(customUserDetails.getEmail());
+        return ResponseEntity.ok(profile);
     }
 }

--- a/backend/src/main/java/org/team4/project/domain/member/dto/MemberProfileResponseDTO.java
+++ b/backend/src/main/java/org/team4/project/domain/member/dto/MemberProfileResponseDTO.java
@@ -1,0 +1,18 @@
+package org.team4.project.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.team4.project.domain.member.entity.Member;
+
+@Data
+@AllArgsConstructor
+public class MemberProfileResponseDTO {
+    private String email;
+    private String nickname;
+    private String role;
+
+    public static MemberProfileResponseDTO of(Member member) {
+        String role = member.getMemberRole().name().toLowerCase();
+        return new MemberProfileResponseDTO(member.getEmail(), member.getNickname(), role);
+    }
+}

--- a/backend/src/main/java/org/team4/project/domain/member/service/MemberService.java
+++ b/backend/src/main/java/org/team4/project/domain/member/service/MemberService.java
@@ -1,11 +1,14 @@
 package org.team4.project.domain.member.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.team4.project.domain.member.dto.MemberProfileResponseDTO;
 import org.team4.project.domain.member.dto.MemberSignUpRequestDTO;
+import org.team4.project.domain.member.entity.Member;
 import org.team4.project.domain.member.exception.RegisterException;
 import org.team4.project.domain.member.repository.MemberRepository;
 
@@ -34,5 +37,10 @@ public class MemberService {
         } catch (DataIntegrityViolationException e) {
             throw new RegisterException("이미 사용중인 이메일 또는 닉네임 입니다.");
         }
+    }
+
+    public MemberProfileResponseDTO getProfile(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+        return MemberProfileResponseDTO.of(member);
     }
 }

--- a/backend/src/main/java/org/team4/project/global/security/SecurityConfig.java
+++ b/backend/src/main/java/org/team4/project/global/security/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);
+        configuration.setExposedHeaders(List.of("Authorization"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 
 import { useState } from "react";
+import type { FieldErrors } from "@/lib/validation/auth";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,9 +13,23 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Eye, EyeOff, User, Building } from "lucide-react";
 import Logo from "@/components/logo";
+import {
+  validateEmail,
+  validatePassword,
+  validateConfirmPassword,
+  validateNickname,
+} from "@/lib/validation/auth";
 
 export default function SignupPage() {
-  const [formData, setFormData] = useState({
+  type SignupForm = {
+    nickname: string;
+    email: string;
+    password: string;
+    confirmPassword: string;
+    userType: "client" | "freelancer";
+  };
+
+  const [formData, setFormData] = useState<SignupForm>({
     nickname: "",
     email: "",
     password: "",
@@ -26,38 +41,89 @@ export default function SignupPage() {
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
+  const validateAll = (state: typeof formData): FieldErrors => ({
+    email: validateEmail(state.email),
+    password: validatePassword(state.password),
+    confirmPassword: validateConfirmPassword(state.password, state.confirmPassword),
+    nickname: validateNickname(state.nickname),
+  });
+
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(() =>
+    validateAll({
+      email: "",
+      password: "",
+      confirmPassword: "",
+      nickname: "",
+      userType: "freelancer",
+    }),
+  );
+
+  const isValid = Object.values(fieldErrors).every((v) => !v);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
     setError("");
 
-    if (formData.password !== formData.confirmPassword) {
-      setError("비밀번호가 일치하지 않습니다.");
-      setIsLoading(false);
-      return;
-    }
-
-    if (formData.password.length < 8) {
-      setError("비밀번호는 8자 이상이어야 합니다.");
+    // 제출 시 최종 검증 (한 번 더 동기화)
+    const latestErrors = validateAll(formData);
+    setFieldErrors(latestErrors);
+    const latestValid = Object.values(latestErrors).every((v) => !v);
+    if (!latestValid) {
       setIsLoading(false);
       return;
     }
 
     try {
-      // 실제 회원가입 로직 구현
-      await new Promise((resolve) => setTimeout(resolve, 1000)); // 임시 딜레이
+      const payload = {
+        email: formData.email.trim(),
+        password: formData.password,
+        nickname: formData.nickname.trim(),
+        role: formData.userType === "client" ? "CLIENT" : "FREELANCER",
+      };
+
+      const response = await fetch("http://localhost:8080/api/v1/auth/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        // 서버가 표준 에러 응답을 JSON으로 내려주는 경우 처리
+        let message = "회원가입 중 오류가 발생했습니다.";
+        try {
+          const data = await response.json();
+          // 가능한 필드들에서 메시지 추출 (message, error, errors[0].defaultMessage 등)
+          if (data?.message) message = data.message;
+          else if (data?.error) message = data.error;
+          else if (Array.isArray(data?.errors) && data.errors.length > 0) {
+            message = data.errors[0]?.defaultMessage || data.errors[0]?.message || message;
+          }
+        } catch (_) {
+          // json 파싱 실패 시 기본 메시지 유지
+        }
+        throw new Error(message);
+      }
 
       // 성공 시 로그인 페이지로 리다이렉트
       window.location.href = "/auth/login";
     } catch (err) {
-      setError("회원가입 중 오류가 발생했습니다.");
+      const message = err instanceof Error ? err.message : "회원가입 중 오류가 발생했습니다.";
+      setError(message);
     } finally {
       setIsLoading(false);
     }
   };
 
   const handleInputChange = (field: string, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
+    setFormData((prev) => {
+      const next = { ...prev, [field]: value };
+      const nextErrors = validateAll(next);
+      setFieldErrors(nextErrors);
+      return next;
+    });
   };
 
   return (
@@ -76,7 +142,7 @@ export default function SignupPage() {
             <CardDescription className="text-center">필요한 정보를 입력해주세요</CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-4" noValidate>
               {error && (
                 <Alert variant="destructive">
                   <AlertDescription>{error}</AlertDescription>
@@ -119,9 +185,11 @@ export default function SignupPage() {
                   placeholder="닉네임을 입력하세요"
                   value={formData.nickname}
                   onChange={(e) => handleInputChange("nickname", e.target.value)}
-                  required
                   className="bg-input border-border"
                 />
+                {fieldErrors.nickname && (
+                  <p className="text-destructive mt-1 text-sm">{fieldErrors.nickname}</p>
+                )}
               </div>
 
               <div className="space-y-2">
@@ -132,9 +200,12 @@ export default function SignupPage() {
                   placeholder="example@email.com"
                   value={formData.email}
                   onChange={(e) => handleInputChange("email", e.target.value)}
-                  required
                   className="bg-input border-border"
+                  autoComplete="email"
                 />
+                {fieldErrors.email && (
+                  <p className="text-destructive mt-1 text-sm">{fieldErrors.email}</p>
+                )}
               </div>
 
               <div className="space-y-2">
@@ -146,7 +217,6 @@ export default function SignupPage() {
                     placeholder="8자 이상 입력하세요"
                     value={formData.password}
                     onChange={(e) => handleInputChange("password", e.target.value)}
-                    required
                     className="bg-input border-border pr-10"
                   />
                   <Button
@@ -163,6 +233,9 @@ export default function SignupPage() {
                     )}
                   </Button>
                 </div>
+                {fieldErrors.password && (
+                  <p className="text-destructive mt-1 text-sm">{fieldErrors.password}</p>
+                )}
               </div>
 
               <div className="space-y-2">
@@ -174,7 +247,6 @@ export default function SignupPage() {
                     placeholder="비밀번호를 다시 입력하세요"
                     value={formData.confirmPassword}
                     onChange={(e) => handleInputChange("confirmPassword", e.target.value)}
-                    required
                     className="bg-input border-border pr-10"
                   />
                   <Button
@@ -191,12 +263,15 @@ export default function SignupPage() {
                     )}
                   </Button>
                 </div>
+                {fieldErrors.confirmPassword && (
+                  <p className="text-destructive mt-1 text-sm">{fieldErrors.confirmPassword}</p>
+                )}
               </div>
 
               <Button
                 type="submit"
                 className="bg-primary hover:bg-primary/90 w-full"
-                disabled={isLoading}
+                disabled={!isValid || isLoading}
               >
                 {isLoading ? "가입 중..." : "회원가입"}
               </Button>

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import type { FieldErrors } from "@/lib/validation/auth";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,7 @@ import {
 } from "@/lib/validation/auth";
 
 export default function SignupPage() {
+  const router = useRouter();
   type SignupForm = {
     nickname: string;
     email: string;
@@ -107,8 +109,8 @@ export default function SignupPage() {
         throw new Error(message);
       }
 
-      // 성공 시 로그인 페이지로 리다이렉트
-      window.location.href = "/auth/login";
+      // 성공 시 로그인 페이지로 리다이렉트 (클라이언트 라우팅)
+      router.replace("/auth/login");
     } catch (err) {
       const message = err instanceof Error ? err.message : "회원가입 중 오류가 발생했습니다.";
       setError(message);

--- a/frontend/src/hooks/use-Login.ts
+++ b/frontend/src/hooks/use-Login.ts
@@ -1,11 +1,19 @@
 import { useLoginStore } from "@/store/useLoginStore";
+import { backendLogout, clearAccessToken } from "@/lib/api";
 
 export default function useLogin() {
   const { member, setMember } = useLoginStore();
 
   const isLoggedIn = member !== null;
 
-  const logout = () => setMember(null);
+  const logout = async () => {
+    try {
+      clearAccessToken();
+      await backendLogout();
+    } finally {
+      setMember(null);
+    }
+  };
 
   return { member, setMember, isLoggedIn, logout };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,79 @@
+export function setAccessToken(token: string | null) {
+  const { setAccessToken } = require("@/store/useLoginStore").useLoginStore.getState();
+  setAccessToken(token);
+}
+
+export function getAccessToken(): string | null {
+  const { accessToken } = require("@/store/useLoginStore").useLoginStore.getState();
+  return accessToken;
+}
+
+export function clearAccessToken() {
+  const { clearAccessToken } = require("@/store/useLoginStore").useLoginStore.getState();
+  clearAccessToken();
+}
+
+function extractBearerFromAuthHeader(value: string | null): string | null {
+  if (!value) return null;
+  const parts = value.split(" ");
+  if (parts.length === 2 && /^Bearer$/i.test(parts[0])) return parts[1];
+  return value;
+}
+
+export async function refreshAccessToken(): Promise<boolean> {
+  try {
+    const resp = await fetch("http://localhost:8080/api/v1/auth/token/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+    if (!resp.ok) return false;
+    const newAuth = resp.headers.get("Authorization");
+    const token = extractBearerFromAuthHeader(newAuth);
+    if (token) {
+      setAccessToken(token);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export async function authorizedFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const token = getAccessToken();
+  const headers = new Headers(init.headers || {});
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const first = await fetch(input, {
+    ...init,
+    headers,
+    credentials: init.credentials ?? "include",
+  });
+  if (first.status !== 401) return first;
+
+  // try refresh once
+  const refreshed = await refreshAccessToken();
+  if (!refreshed) {
+    // refresh 실패 시 로그아웃 및 이동
+    try {
+      await backendLogout();
+    } finally {
+      clearAccessToken();
+      if (typeof window !== "undefined") window.location.href = "/auth/login";
+    }
+    return first;
+  }
+
+  const newToken = getAccessToken();
+  const headers2 = new Headers(init.headers || {});
+  if (newToken) headers2.set("Authorization", `Bearer ${newToken}`);
+  return fetch(input, { ...init, headers: headers2, credentials: init.credentials ?? "include" });
+}
+
+export async function backendLogout(): Promise<void> {
+  try {
+    await fetch("http://localhost:8080/api/v1/auth/token/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  } catch {}
+}

--- a/frontend/src/lib/validation/auth.ts
+++ b/frontend/src/lib/validation/auth.ts
@@ -1,0 +1,32 @@
+export type FieldKey = "email" | "password" | "confirmPassword" | "nickname";
+export type FieldErrors = Partial<Record<FieldKey, string>>;
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateEmail(emailRaw: string): string {
+  const email = emailRaw.trim();
+  if (!email) return "이메일은 필수 입력입니다.";
+  if (!EMAIL_REGEX.test(email)) return "이메일 형식이 올바르지 않습니다.";
+  return "";
+}
+
+export function validatePassword(password: string): string {
+  if (!password) return "비밀번호는 필수 입력입니다.";
+  if (password.length < 8 || password.length > 20) {
+    return "비밀번호는 8자 이상 20자 이하여야 합니다.";
+  }
+  return "";
+}
+
+export function validateConfirmPassword(password: string, confirmPassword: string): string {
+  if (!confirmPassword) return "비밀번호 확인은 필수 입력입니다.";
+  if (password !== confirmPassword) return "비밀번호가 일치하지 않습니다.";
+  return "";
+}
+
+export function validateNickname(nicknameRaw: string): string {
+  const nickname = nicknameRaw.trim();
+  if (!nickname) return "닉네임은 필수 입력입니다.";
+  if (nickname.length < 2 || nickname.length > 20) return "닉네임은 2자 이상 20자 이하여야 합니다.";
+  return "";
+}

--- a/frontend/src/store/useLoginStore.ts
+++ b/frontend/src/store/useLoginStore.ts
@@ -9,9 +9,15 @@ interface Member {
 interface LoginState {
   member: Member | null;
   setMember: (member: Member | null) => void;
+  accessToken: string | null;
+  setAccessToken: (token: string | null) => void;
+  clearAccessToken: () => void;
 }
 
 export const useLoginStore = create<LoginState>((set) => ({
-  member: { email: "aaa@naver.com", nickname: "정다솔", role: "freelancer" },
+  member: null,
   setMember: (member) => set({ member }),
+  accessToken: null,
+  setAccessToken: (token) => set({ accessToken: token }),
+  clearAccessToken: () => set({ accessToken: null }),
 }));


### PR DESCRIPTION
## 긴급 처리 사유

## 📂 작업 내용

closes #25 

- [x] 회원가입, 로그인, 로그아웃 api 연동

## 💡 자세한 설명

- 프론트에서 이메일, 비밀번호 등 입력 값 검증
- 회원가입 API 연동
- 프로필 조회용 API 추가
- 로그인 API 연동(로그인 성공 시 accessToken zustand 저장 -> 프로필 조회 API 호출 -> 프로필 정보 zustand 저장 -> "/" 라우트)
- api.ts에 authorizedFetch를 추가하여, 인증이 필요한 API 호출 시 자동으로 인증 헤더를 붙이고, 토큰 만료 시에는 토큰 재발급 후 기존 요청을 재시도하도록 구현
- 로그아웃 API 연동(zustand에서 관리하던 member, accessToken null 값으로 초기화)

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
- 회원 가입 시 이메일 인증 추가

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [ ] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Implemented full login flow with token-based auth, auto-refresh, and profile retrieval after sign-in.
  - Added client-side validation for login and signup (email, password, nickname, confirmation) with inline error messages.
  - Enabled signup with backend integration and post-signup redirect to login.
- Bug Fixes
  - Improved logout reliability and ensured state clears even if server calls fail.
  - Better error handling and messaging for auth failures.
- Chores
  - Updated security to expose Authorization header for frontend token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->