### PR TITLE
:bug: fix : payment 페이지 에러 메시지 버그 수정

### DIFF
--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -10,6 +10,7 @@ import { CreditCard, Shield, Lock, AlertCircle } from "lucide-react";
 import { loadTossPayments } from "@tosspayments/tosspayments-sdk";
 import { v4 as uuidv4 } from "uuid";
 import { useLoginStore } from "@/store/useLoginStore";
+import { authorizedFetch } from "@/lib/api";
 
 const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY!;
 const customerKey = uuidv4();
@@ -27,13 +28,6 @@ export default function PaymentPage() {
   const memo = searchParams.get("memo") || "웹사이트 디자인 및 개발 프로젝트 1차 결제입니다.";
   const serviceName = searchParams.get("service") || "웹사이트 디자인 및 개발";
   const chatId = searchParams.get("chatId") || "";
-
-  // Check authentication
-  useEffect(() => {
-    if (!member) {
-      setError("결제를 진행하려면 로그인이 필요합니다.");
-    }
-  }, [member]);
 
   // 토스페이먼츠 위젯 초기화
   useEffect(() => {
@@ -59,6 +53,11 @@ export default function PaymentPage() {
   }, [clientKey, customerKey]);
 
   const handlePayment = async () => {
+    if (!member) {
+      setError("결제를 진행하려면 로그인이 필요합니다.");
+      return;
+    }
+
     setIsProcessing(true);
     setError("");
     try {
@@ -67,7 +66,7 @@ export default function PaymentPage() {
 
       // 1단계: 결제를 요청하기 전에 orderId, amount를 서버에 저장
       // 결제 과정에서 악의적으로 결제 금액이 바뀌는 것을 확인하는 용도
-      const saveResponse = await fetch(`${baseUrl}/api/v1/payments/save`, {
+      const saveResponse = await authorizedFetch(`${baseUrl}/api/v1/payments/save`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/app/payment/success/page.tsx
+++ b/frontend/src/app/payment/success/page.tsx
@@ -22,6 +22,7 @@ export default function PaymentSuccessPage() {
   const amount = searchParams.get("amount");
   const chatId = searchParams.get("chatId");
   const memo = searchParams.get("memo");
+  const serviceId = searchParams.get("serviceId");
 
   // 결제 승인 요청
   useEffect(() => {
@@ -38,6 +39,7 @@ export default function PaymentSuccessPage() {
         amount: parseInt(amount),
         paymentKey: paymentKey,
         memo: memo || "",
+        serviceId: serviceId,
       };
 
       try {


### PR DESCRIPTION
## 긴급 처리 사유

결제 페이지 setError 타이밍 버그

## 📂 작업 내용

closes #이슈번호

- [x] /payment 페이지 로그인 useEffect 제거
- [x] 결제하기 버튼 눌렀을 때(`handlePayment`) setError 하도록 수정

## 💡 자세한 설명

`isHydrated` 추가보다는 useEffect를 제거하고 "결제하기" 버튼 눌렀을 때 `if (!member) setError(...)` 방식이 더 깔끔한 것 같아서 이렇게 수정했습니다.


## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
