### PR TITLE
Feat/profile

### DIFF
--- a/backend/src/main/java/org/team4/project/domain/profile/dto/ClientProfileResponse.java
+++ b/backend/src/main/java/org/team4/project/domain/profile/dto/ClientProfileResponse.java
@@ -11,6 +11,7 @@ public class ClientProfileResponse {
     private final String nickname;
     private final String introduction;
     private final double averageRating;
+    private final String profileImageUrl;
 
     // 클라이언트 필드
     private final String companyName;
@@ -23,6 +24,7 @@ public class ClientProfileResponse {
                 .averageRating(clientProfile.getAverageRating())
                 .companyName(clientProfile.getCompanyName())
                 .teamName(clientProfile.getTeamName())
+                .profileImageUrl(clientProfile.getProfileImageUrl())
                 .build();
     }
 }

--- a/backend/src/main/java/org/team4/project/domain/profile/dto/FreelancerProfileResponse.java
+++ b/backend/src/main/java/org/team4/project/domain/profile/dto/FreelancerProfileResponse.java
@@ -14,6 +14,7 @@ public class FreelancerProfileResponse {
     private final String nickname;
     private final String introduction;
     private final double averageRating;
+    private final String profileImageUrl;
 
     // 프리랜서 필드
     private final List<String> techStacks;
@@ -34,6 +35,7 @@ public class FreelancerProfileResponse {
                 .portfolios(freelancerProfile.getPortfolios().stream()
                         .map(PortfolioResponseDto::from)
                         .collect(Collectors.toList()))
+                .profileImageUrl(freelancerProfile.getProfileImageUrl())
                 .build();
     }
 }

--- a/backend/src/main/java/org/team4/project/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/team4/project/global/exception/GlobalExceptionHandler.java
@@ -129,7 +129,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ErrorResponse.of(request, message), HttpStatus.NOT_FOUND);
     }
 
-    //
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.warn("error at [{} {}]: {}",

--- a/frontend/src/components/service-card.tsx
+++ b/frontend/src/components/service-card.tsx
@@ -1,8 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Star, Edit } from "lucide-react";
+import { Star } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { ServiceCardType } from "@/app/type/service";
 
 interface ServiceCardProps extends ServiceCardType {
@@ -41,12 +40,6 @@ export function ServiceCard({
 
         <div className="mb-2 flex items-center justify-between">
           <span className="text-primary text-lg font-bold">{price.toLocaleString()}원</span>
-
-          {variant === "mypage" && (
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <Edit className="h-4 w-4" />
-            </Button>
-          )}
         </div>
 
         <div className="flex items-center justify-between text-sm">


### PR DESCRIPTION
## 긴급 처리 사유

## 📂 작업 내용

closes #99 

- [x] 프리랜서, 클라이언트 프로필 조회 API 이미지 추가
- [x] 마이 페이지 서비스 탭 서비스 수정 버튼 삭제

## 💡 자세한 설명

- 마이 페이지 서비스 탭의 수정 아이콘이 ServiceCard 컴포넌트에 포함되어있어서 ServiceCard 컴포넌트에서 아이콘 제거 하였는데,
ServiceCard 컴포넌트를 사용하는 페이지들을 봤을 때 문제는 없었지만, 문제가 생길 경우 처리 필요

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
