### PR TITLE
버튼 비활성화 / 요소 이름 변경

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
         "geist": "^1.5.1",
+        "html2canvas": "^1.4.1",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.544.0",
         "next": "15.5.4",
@@ -2934,6 +2935,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.9.tgz",
@@ -3190,6 +3200,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -4706,6 +4725,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-parser-js": {
@@ -7087,6 +7119,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -7486,6 +7527,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "geist": "^1.5.1",
+    "html2canvas": "^1.4.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",

--- a/frontend/src/app/mypage/chatcanvas/[id]/page.tsx
+++ b/frontend/src/app/mypage/chatcanvas/[id]/page.tsx
@@ -18,9 +18,7 @@ export default function ChatCanvasPage() {
   const [color, setColor] = useState("#ff0000");
   const [lineWidth, setLineWidth] = useState(2);
   const [imageLoaded, setImageLoaded] = useState(false);
-  const [orientation, setOrientation] = useState<"landscape" | "portrait">(
-    "landscape",
-  );
+  const [orientation, setOrientation] = useState<"landscape" | "portrait">("landscape");
 
   const websocketService = useRef(new WebsocketService());
 
@@ -254,7 +252,7 @@ export default function ChatCanvasPage() {
 
   return (
     <div style={{ padding: "2rem" }}>
-      <h1 style={{ fontSize: "2rem", fontWeight: "bold", marginBottom: "1.5rem" }}>그림판</h1>
+      <h1 style={{ fontSize: "2rem", fontWeight: "bold", marginBottom: "1.5rem" }}>회의실</h1>
 
       <div style={{ marginBottom: "10px", display: "flex", alignItems: "center", gap: "10px" }}>
         <button onClick={() => setTool("pen")}>펜</button>
@@ -281,6 +279,45 @@ export default function ChatCanvasPage() {
           style={{ backgroundColor: orientation === "portrait" ? "#4CAF50" : "#eee" }}
         >
           세로 (PDF)
+        </button>
+
+        {/* 파일 추가 */}
+        <label style={{ padding: "0.5rem 1rem", backgroundColor: "#eee", cursor: "pointer" }}>
+          파일 추가
+          <input
+            type="file"
+            accept=".pdf,.png,.jpg,.jpeg"
+            style={{ display: "none" }}
+            onChange={handleFileInputChange}
+          />
+        </label>
+
+        {/* 파일로 저장 버튼 추가 */}
+        <button
+          onClick={() => {
+            const bgCanvas = bgCanvasRef.current;
+            const drawCanvas = drawCanvasRef.current;
+            if (!bgCanvas || !drawCanvas) return;
+
+            // 임시 캔버스 생성
+            const tempCanvas = document.createElement("canvas");
+            tempCanvas.width = bgCanvas.width;
+            tempCanvas.height = bgCanvas.height;
+            const ctx = tempCanvas.getContext("2d");
+            if (!ctx) return;
+
+            // 배경 + 드로잉 합성
+            ctx.drawImage(bgCanvas, 0, 0);
+            ctx.drawImage(drawCanvas, 0, 0);
+
+            // 이미지 다운로드
+            const link = document.createElement("a");
+            link.download = `canvas-${Date.now()}.png`;
+            link.href = tempCanvas.toDataURL("image/png");
+            link.click();
+          }}
+        >
+          파일로 저장
         </button>
       </div>
 

--- a/frontend/src/app/mypage/chatcanvas/[id]/page.tsx
+++ b/frontend/src/app/mypage/chatcanvas/[id]/page.tsx
@@ -1,8 +1,14 @@
 "use client";
+
 import { useRef, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { useLoginStore } from "@/store/useLoginStore";
 import { WebsocketService, DrawingAction } from "./websocket-service";
+import * as pdfjsLib_ from "pdfjs-dist/legacy/build/pdf";
+const pdfjsLib = pdfjsLib_ as any;
+
+// PDF.js 워커 경로 설정
+pdfjsLib.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;
 
 export default function ChatCanvasPage() {
   const params = useParams();
@@ -32,7 +38,7 @@ export default function ChatCanvasPage() {
       ctx.globalCompositeOperation = "source-over";
       ctx.strokeStyle = color;
       ctx.lineWidth = lineWidth;
-    } else if (tool === "eraser") {
+    } else {
       ctx.globalCompositeOperation = "destination-out";
       ctx.lineWidth = lineWidth * 10;
     }
@@ -57,15 +63,17 @@ export default function ChatCanvasPage() {
       bgCanvas.width = container.offsetWidth;
       bgCanvas.height = container.offsetHeight;
 
-      const bgCtx = bgCanvas.getContext("2d");
-      if (bgCtx) {
-        const img = new Image();
-        img.src = "/example.jpg";
-        img.onload = () => {
-          bgCtx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
-          bgCtx.drawImage(img, 0, 0, bgCanvas.width, bgCanvas.height);
-          setImageLoaded(true);
-        };
+      if (!imageLoaded) {
+        const bgCtx = bgCanvas.getContext("2d");
+        if (bgCtx) {
+          const img = new Image();
+          img.src = "/example.jpg";
+          img.onload = () => {
+            bgCtx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
+            bgCtx.drawImage(img, 0, 0, bgCanvas.width, bgCanvas.height);
+            setImageLoaded(true);
+          };
+        }
       }
     }
 
@@ -89,17 +97,13 @@ export default function ChatCanvasPage() {
   useEffect(() => {
     redrawCanvas();
     setImageLoaded(true);
-    window.addEventListener("resize", () => redrawCanvas(true));
-    return () => window.removeEventListener("resize", () => redrawCanvas(true));
+    const resizeHandler = () => redrawCanvas(true);
+    window.addEventListener("resize", resizeHandler);
+    return () => window.removeEventListener("resize", resizeHandler);
   }, []);
 
-  useEffect(() => {
-    applyToolSettings();
-  }, [tool, color, lineWidth]);
-
-  useEffect(() => {
-    redrawCanvas(true);
-  }, [orientation]);
+  useEffect(() => applyToolSettings(), [tool, color, lineWidth]);
+  useEffect(() => redrawCanvas(true), [orientation]);
 
   useEffect(() => {
     const handleRemoteDrawingAction = (action: DrawingAction) => {
@@ -108,7 +112,7 @@ export default function ChatCanvasPage() {
       const ctx = canvas.getContext("2d");
       if (!ctx) return;
 
-      if (action.type == "START" || action.type == "DRAW") {
+      if (action.type === "START" || action.type === "DRAW") {
         ctx.strokeStyle = action.color;
         ctx.lineWidth = action.lineWidth;
         ctx.globalCompositeOperation = action.tool === "pen" ? "source-over" : "destination-out";
@@ -140,9 +144,7 @@ export default function ChatCanvasPage() {
       websocketService.current.connect(canvasId, accessToken, handleRemoteDrawingAction);
     }
 
-    return () => {
-      websocketService.current.disconnect();
-    };
+    return () => websocketService.current.disconnect();
   }, [canvasId, accessToken]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -156,7 +158,7 @@ export default function ChatCanvasPage() {
     ctx.beginPath();
     ctx.moveTo(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
 
-    const action: DrawingAction = {
+    websocketService.current.sendDrawingAction(canvasId, {
       canvasId,
       type: "START",
       x: e.nativeEvent.offsetX,
@@ -164,8 +166,7 @@ export default function ChatCanvasPage() {
       color,
       lineWidth,
       tool,
-    };
-    websocketService.current.sendDrawingAction(canvasId, action);
+    });
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
@@ -192,7 +193,7 @@ export default function ChatCanvasPage() {
     ctx.beginPath();
     ctx.moveTo(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
 
-    const action: DrawingAction = {
+    websocketService.current.sendDrawingAction(canvasId, {
       canvasId,
       type: "DRAW",
       x: e.nativeEvent.offsetX,
@@ -200,15 +201,13 @@ export default function ChatCanvasPage() {
       color,
       lineWidth,
       tool,
-    };
-    websocketService.current.sendDrawingAction(canvasId, action);
+    });
   };
 
   const handleMouseUp = () => {
     if (!canvasId) return;
     isDrawing.current = false;
-
-    const action: DrawingAction = {
+    websocketService.current.sendDrawingAction(canvasId, {
       canvasId,
       type: "END",
       x: 0,
@@ -216,10 +215,8 @@ export default function ChatCanvasPage() {
       color: "",
       lineWidth: 0,
       tool: "pen",
-    };
-    websocketService.current.sendDrawingAction(canvasId, action);
+    });
   };
-
   const handleMouseLeave = () => {
     isDrawing.current = false;
   };
@@ -232,7 +229,7 @@ export default function ChatCanvasPage() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     if (sendAction && canvasId) {
-      const action: DrawingAction = {
+      websocketService.current.sendDrawingAction(canvasId, {
         canvasId,
         type: "CLEAR",
         x: 0,
@@ -240,10 +237,73 @@ export default function ChatCanvasPage() {
         color: "",
         lineWidth: 0,
         tool: "pen",
-      };
-      websocketService.current.sendDrawingAction(canvasId, action);
+      });
     }
   };
+
+  // ========================
+  // 파일 업로드
+  // ========================
+  const handleFile = async (file: File) => {
+    const bgCanvas = bgCanvasRef.current;
+    if (!bgCanvas) return;
+    const ctx = bgCanvas.getContext("2d");
+    if (!ctx) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    bgCanvas.width = container.offsetWidth;
+    bgCanvas.height = container.offsetHeight;
+
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    if (!ext) return;
+
+    if (ext === "pdf") {
+      const arrayBuffer = await file.arrayBuffer();
+      const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+      const page = await pdf.getPage(1);
+      const viewport = page.getViewport({ scale: 1 });
+      const scale = Math.min(
+        container.offsetWidth / viewport.width,
+        container.offsetHeight / viewport.height,
+      );
+      const scaledViewport = page.getViewport({ scale });
+
+      const tempCanvas = document.createElement("canvas");
+      const tempCtx = tempCanvas.getContext("2d");
+      if (!tempCtx) return;
+      tempCanvas.width = scaledViewport.width;
+      tempCanvas.height = scaledViewport.height;
+
+      await page.render({ canvasContext: tempCtx, viewport: scaledViewport }).promise;
+      ctx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
+      ctx.drawImage(tempCanvas, 0, 0, bgCanvas.width, bgCanvas.height);
+      setImageLoaded(true);
+    } else if (["png", "jpg", "jpeg"].includes(ext)) {
+      const img = new Image();
+      img.src = URL.createObjectURL(file);
+      img.onload = () => {
+        ctx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
+        ctx.drawImage(img, 0, 0, bgCanvas.width, bgCanvas.height);
+        setImageLoaded(true);
+      };
+    } else {
+      alert("지원하지 않는 파일 형식입니다. PDF 또는 이미지 파일만 가능합니다.");
+    }
+  };
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
 
   const containerStyle =
     orientation === "landscape"
@@ -281,7 +341,6 @@ export default function ChatCanvasPage() {
           세로 (PDF)
         </button>
 
-        {/* 파일 추가 */}
         <label style={{ padding: "0.5rem 1rem", backgroundColor: "#eee", cursor: "pointer" }}>
           파일 추가
           <input
@@ -292,25 +351,21 @@ export default function ChatCanvasPage() {
           />
         </label>
 
-        {/* 파일로 저장 버튼 추가 */}
         <button
           onClick={() => {
             const bgCanvas = bgCanvasRef.current;
             const drawCanvas = drawCanvasRef.current;
             if (!bgCanvas || !drawCanvas) return;
 
-            // 임시 캔버스 생성
             const tempCanvas = document.createElement("canvas");
             tempCanvas.width = bgCanvas.width;
             tempCanvas.height = bgCanvas.height;
             const ctx = tempCanvas.getContext("2d");
             if (!ctx) return;
 
-            // 배경 + 드로잉 합성
             ctx.drawImage(bgCanvas, 0, 0);
             ctx.drawImage(drawCanvas, 0, 0);
 
-            // 이미지 다운로드
             const link = document.createElement("a");
             link.download = `canvas-${Date.now()}.png`;
             link.href = tempCanvas.toDataURL("image/png");
@@ -323,6 +378,8 @@ export default function ChatCanvasPage() {
 
       <div
         ref={containerRef}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
         style={{
           position: "relative",
           border: "1px solid black",

--- a/frontend/src/types/pdfjs.d.ts
+++ b/frontend/src/types/pdfjs.d.ts
@@ -1,0 +1,9 @@
+declare module "pdfjs-dist/legacy/build/pdf" {
+  const pdfjs: any;
+  export = pdfjs;
+}
+
+declare module "pdfjs-dist" {
+  const pdfjs: any;
+  export = pdfjs;
+}


### PR DESCRIPTION
## 긴급 처리 사유

## 📂 작업 내용

closes #이슈번호

- [x] 프론트에서 버튼 클릭 시 비활성화
- [x] 이름 변경
- [x] 캔버스에 이미지 추가
- [x] 현재 캔버스 파일로 저장 가능

## 💡 자세한 설명
- 결제 -> 결제완료, 확인 -> 확인 완료 후 클릭 비활성화되게 해놨습니다(다만 프론트만 구현해서 새로고침하면 돌아감)

- 이름 변경(화상 회의 -> 회의, 그림판 -> 회의실 등)

- 캔버스에 이미지 파일 드래그 or 파일 추가로 배경으로 띄우기 가능(웹소켓 연결이 안되어 상대 쪽에선 보이지 않습니다)

- 현재 캔버스 그대로 이미지 파일로 저장 가능(가로, 세로 설정에 따라 해당 비율로 저장)


## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
